### PR TITLE
Updates so all tests pass

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -13,7 +13,7 @@ DEPENDENCIES:
   - VVJSONSchemaValidation (~> 1.3)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Expecta
     - ObjectiveSugar
     - Specta
@@ -32,4 +32,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: abd6914286eceb417a0fbf867e2c1826546083a7
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.8.4

--- a/Example/Tests/HKObject+Private.h
+++ b/Example/Tests/HKObject+Private.h
@@ -20,7 +20,7 @@
 @interface HKObject (Private)
 
 // source:
-// https://github.com/nst/iOS-Runtime-Headers/blob/e578efc846bd46a2d24a4fdd033cdc582323ccec/Frameworks/HealthKit.framework/HKObject.h#L55
-- (BOOL)_validateForSavingWithClientEntitlements:(id)arg1 error:(id*)arg2;
+// https://github.com/LeoNatan/Apple-Runtime-Headers/blob/master/iOS/Frameworks/HealthKit.framework/HKObject.h
+- (BOOL)_validateForSavingWithClientEntitlements:(id)arg1 applicationSDKVersion:(unsigned int)arg2 error:(id *)arg3;
 
 @end

--- a/Example/Tests/OMHSampleFactory.m
+++ b/Example/Tests/OMHSampleFactory.m
@@ -224,7 +224,7 @@
     // see HKObject+Private.h
     // NOTE: throws _HKObjectValidationFailureException if invalid
     
-    [sample _validateForSavingWithClientEntitlements:nil error:nil];
+    [sample _validateForSavingWithClientEntitlements:nil applicationSDKVersion:11 error:nil];
     return sample;
 }
 

--- a/Example/Tests/OMHSerializerTests.m
+++ b/Example/Tests/OMHSerializerTests.m
@@ -1135,7 +1135,7 @@ describe(@"HKQuantityTypeIdentifierBodyFatPercentage with time_interval", ^{
     itShouldBehaveLike(@"AnySerializerForSupportedSample",^{
         NSDate *start = [NSDate date];
         NSDate *end = [start dateByAddingTimeInterval:3600];
-        NSNumber *value = [NSNumber  numberWithDouble:.232];
+        NSNumber *value = [NSNumber  numberWithDouble:.231];
         NSString *unitString = @"%";
         HKSample *sample = [OMHSampleFactory typeIdentifier:HKQuantityTypeIdentifierBodyFatPercentage
                                                       attrs:@{@"value":value,
@@ -1148,7 +1148,7 @@ describe(@"HKQuantityTypeIdentifierBodyFatPercentage with time_interval", ^{
                          @"header.schema_id.name": @"body-fat-percentage",
                          @"header.schema_id.namespace":@"omh",
                          @"header.schema_id.version": @"1.0",
-                         @"body.body_fat_percentage.value": @23.2,
+                         @"body.body_fat_percentage.value": @23.1,
                          @"body.body_fat_percentage.unit": unitString,
                          @"body.effective_time_frame.time_interval.start_date_time": [sample.startDate RFC3339String],
                          @"body.effective_time_frame.time_interval.end_date_time": [sample.endDate RFC3339String]

--- a/Pod/Classes/OMHSerializer.m
+++ b/Pod/Classes/OMHSerializer.m
@@ -796,7 +796,7 @@
         
         [serializedUnitValues addEntriesFromDictionary:@{
                                                          @"unit_value":@{
-                                                                 @"value": @([value floatValue] * 100),
+                                                                 @"value": @([value doubleValue] * 100),
                                                                  @"unit": @"%"
                                                                  }
                                                          }


### PR DESCRIPTION
Update for new cocoapods version, HealthKit 11.x, and using doubleValue to resolve 2 unit tests